### PR TITLE
zoom map fixé

### DIFF
--- a/app/javascript/plugins/init_mapbox.js
+++ b/app/javascript/plugins/init_mapbox.js
@@ -35,9 +35,12 @@ const addMarkersToMap = (map, markers) => {
 
 const fitMapToMarkers = (map, markers) => {
   const bounds = new mapboxgl.LngLatBounds();
-  markers.forEach(marker => bounds.extend([ marker.lng, marker.lat ]));
-  map.fitBounds(bounds, { padding: 70, maxZoom: 15 });
-  map.scrollZoom.disable();
+  markers.forEach(marker => {
+    if (marker.lng !== null && marker.lat !== null) {
+      bounds.extend([ marker.lng, marker.lat ])
+    }
+  });
+  map.fitBounds(bounds, { padding: 70, maxZoom: 15, duration: 0 });
 };
 
 const initMapbox = () => {
@@ -51,7 +54,9 @@ const initMapbox = () => {
         maxZoom: 11
       },
       trackUserLocation: true
+
     }));
+
     const markers = JSON.parse(mapElement.dataset.markers);
     addMarkersToMap(map, markers);
     fitMapToMarkers(map, markers);


### PR DESCRIPTION
Ajout de d'une condition dans init_mapbox qui permet lorsqu'un endroit n'a pas d'ID, de fixer la zone de zoom par défaut: 

const fitMapToMarkers = (map, markers) => {
  const bounds = new mapboxgl.LngLatBounds();
  markers.forEach(marker => {
    **if (marker.lng !== null && marker.lat !== null) {
      bounds.extend([ marker.lng, marker.lat ])
    }**
  });